### PR TITLE
Firefox issue with the closeSlider/openSlider functions

### DIFF
--- a/readmore.js
+++ b/readmore.js
@@ -46,7 +46,7 @@
           return true;
         }
         else {
-          current.after($($this.options.moreLink).on('click', function() { $this.openSlider(this, current) }));
+          current.after($($this.options.moreLink).on('click', function(event) { $this.openSlider(this, current, event) }));
         }
 
         sliderHeight = maxHeight;
@@ -55,7 +55,7 @@
       });
     },
 
-    openSlider: function(trigger, element)
+    openSlider: function(trigger, element, event)
     {
       event.preventDefault();
 
@@ -64,10 +64,10 @@
 
       $(element).animate({"height": open_height}, {duration: $this.options.speed });
 
-      $(trigger).replaceWith($($this.options.lessLink).on('click', function() { $this.closeSlider(this, element) }));
+      $(trigger).replaceWith($($this.options.lessLink).on('click', function(event) { $this.closeSlider(this, element, event) }));
     },
 
-    closeSlider: function(trigger, element)
+    closeSlider: function(trigger, element, event)
     {
       event.preventDefault();
 
@@ -75,7 +75,7 @@
 
       $(element).animate({"height": sliderHeight}, {duration: $this.options.speed });
 
-      $(trigger).replaceWith($($this.options.moreLink).on('click', function() { $this.openSlider(this, element) }));
+      $(trigger).replaceWith($($this.options.moreLink).on('click', function(event) { $this.openSlider(this, element, event) }));
     }
   };
 


### PR DESCRIPTION
When we added this library to a project, we found that the open/close slider links weren't working in Firefox. Clicking them would just add the octothorp to the URL and throw an error. This was because the `event` variable within the closeSlider/openSlider functions was not found. 

This patch passes those from the event listener down to the closeSlider/openSlider functions explicitly. I'm guessing some browsers (e.g. Chrome) have this available as a global while others do not.

Thanks for the library, it's quite useful!
