### PR TITLE
Add an option to debounce the window resize event

### DIFF
--- a/readmore.js
+++ b/readmore.js
@@ -20,6 +20,9 @@
         expandedClass: 'readmore-js-expanded',
         collapsedClass: 'readmore-js-collapsed',
 
+        // Should the resize event be debounced? It can prevent the browser from freezing if there are a lot of readmore boxes
+        debounceResize: false,
+
         // callbacks
         beforeToggle: function(){},
         afterToggle: function(){}
@@ -92,9 +95,14 @@
         }
       });
 
-      $(window).on('resize', function(event) {
-        $this.resizeBoxes();
-      });
+      if ($this.options.debounceResize && $.debounce) {
+        $(window).on('resize', $.debounce(250, function() {
+          $this.resizeBoxes();
+        }));
+      }
+      else {
+        $(window).on('resize', $this.resizeBoxes());
+      }
     },
 
     toggleSlider: function(trigger, element, event)


### PR DESCRIPTION
The option is called `debounceResize`, and defaults to false.

If there are lots of text boxes where readmore is applied, resizing the browser window can be a performance killer.

This change adds a dependency to [Ben Alman's throttle/debounce plugin](http://benalman.com/projects/jquery-throttle-debounce-plugin/).

If the plugin is not present, the `debounceResize` option has no effect.