### PR TITLE
Ensure maxHeight is an integer

### DIFF
--- a/readmore.js
+++ b/readmore.js
@@ -76,7 +76,7 @@
 
         $this.setBoxHeight(current);
 
-        if(current.outerHeight(true) <= maxHeight + heightMargin) {
+        if(current.outerHeight(true) <= parseInt(maxHeight) + heightMargin) {
           // The block is shorter than the limit, so there's no need to truncate it.
           return true;
         }


### PR DESCRIPTION
If the height is pulled from the element's CSS, it's a string and thus doesn't add properly (i.e. 300 + 16 = 30016). Using parseInt to ensure it's a number.
