### PR TITLE
Relocate stray semi colon

### DIFF
--- a/readmore.js
+++ b/readmore.js
@@ -5,7 +5,7 @@
  * Licensed under the MIT license
  */
 
-;(function($) {
+(function($) {
 
   var readmore = 'readmore',
       defaults = {
@@ -188,5 +188,5 @@
         }
       });
     }
-  }
+  };
 })(jQuery);


### PR DESCRIPTION
Should the semi colon be at the end of the last function call instead of the beginning of the file?
