### PR TITLE
Added a timeout to prevent resizeBoxes from firing a billion times

### DIFF
--- a/readmore.js
+++ b/readmore.js
@@ -98,7 +98,7 @@
           clearTimeout(resizeTimeout);
         }
 
-        resizeTimeout = setTimeout($proxy($this.resizeBoxes, $this), 200);
+        resizeTimeout = setTimeout($.proxy($this.resizeBoxes, $this), 200);
       });
     },
 

--- a/readmore.js
+++ b/readmore.js
@@ -92,8 +92,13 @@
         }
       });
 
+      var resizeTimeout = false;
       $(window).on('resize', function(event) {
-        $this.resizeBoxes();
+        if(resizeTimeout !== false){
+          clearTimeout(resizeTimeout);
+        }
+
+        resizeTimeout = setTimeout($proxy($this.resizeBoxes, $this), 200);
       });
     },
 


### PR DESCRIPTION
I was running into an issue where I had 20 readmore boxes on a single page and the resizing event was firing a TON of times (there are a lot more purple event bars if I let the recorder continue).

![resize event craziness](https://cloud.githubusercontent.com/assets/371892/3758732/19ec5160-184f-11e4-97c2-d860fdae670e.png)

By setting a timeout (and using $proxy to retain 'this'), I was able to significantly decrease the number of events and speed up the page rendering a ton. There are still 20 rendering blocks (one for each redmore) but it's a big improvement.

![slightly less craziness](https://cloud.githubusercontent.com/assets/371892/3758744/4584cd3e-184f-11e4-89c3-21a05ddb68a8.png)