### PR TITLE
Added .resizeBoxes() to window.onload on init

### DIFF
--- a/readmore.js
+++ b/readmore.js
@@ -92,6 +92,10 @@
         }
       });
 
+      $(window).on('load', function(event) {
+        $this.resizeBoxes();
+      });
+
       $(window).on('resize', function(event) {
         $this.resizeBoxes();
       });


### PR DESCRIPTION
I had the "text being cut off" problem in Issue #51 and I noticed that it resolved itself once I resized the browser. So, until someone figures out the height issue, I'm working around it by calling resizeBoxes() as soon as the window loads.
Note: I am also calling Readmore.js on a div that has one of Bootstrap's .col-* classes extended into it, in case that information is useful to anyone.