### PR TITLE
Fix for https://github.com/jedfoster/Readmore.js/issues/73

### DIFF
--- a/readmore.js
+++ b/readmore.js
@@ -67,7 +67,7 @@
 
       $(this.element).each(function() {
         var current = $(this),
-            maxHeight = (current.css('max-height').replace(/[^-\d\.]/g, '') > current.data('max-height')) ? current.css('max-height').replace(/[^-\d\.]/g, '') : current.data('max-height'),
+            maxHeight = (parseInt(current.css('max-height').replace(/[^-\d\.]/g, ''), 10) > current.data('max-height')) ? parseInt(current.css('max-height').replace(/[^-\d\.]/g, ''), 10) : current.data('max-height'),
             heightMargin = current.data('height-margin');
 
         if(current.css('max-height') != 'none') {


### PR DESCRIPTION
current.css('max-height') returns a string when the max-height of an element is set via CSS (https://github.com/jedfoster/Readmore.js/issues/73). Use parseInt to force to an integer.

The following fiddle demonstrates the issue: http://jsfiddle.net/xk9r38eq/

And this fiddle demonstrates the fix: http://jsfiddle.net/6eu1mmg6/

As can be seen in the console output, the maxHeight can now be added to the heightMargin correctly:

readmore_v2.js:79 -  typeof current.css('max-height').replace(/[^-d.]/g, ''): string
readmore_v2.js:80  - typeof current.data('max-height'): number
readmore_v2.js:81 - typeof maxHeight: number
readmore_v2.js:82 - maxHeight + heightMargin:
readmore_v2.js:83 - 228

Would love to see this get merged this time around.
