### PR TITLE
Set "read more" and "close" button padding and margin

### DIFF
--- a/readmore.js
+++ b/readmore.js
@@ -212,7 +212,14 @@
           .attr({
             'data-readmore-toggle': id,
             'aria-controls': id
-          }));
+          })
+          .css({
+            "padding-left": current.css("padding-left"),
+            "padding-right": current.css("padding-right"),
+            "margin-left": current.css("margin-left"),
+            "margin-right": current.css("margin-right")
+          })
+        );
 
         if (! this.options.startOpen) {
           current.css({
@@ -286,7 +293,13 @@
         .attr({
           'data-readmore-toggle': $element.attr('id'),
           'aria-controls': $element.attr('id')
-        }));
+        }).css({
+          "padding-left": $element.css("padding-left"),
+          "padding-right": $element.css("padding-right"),
+          "margin-left": $element.css("margin-left"),
+          "margin-right": $element.css("margin-right")
+        })
+      );
     },
 
     destroy: function() {


### PR DESCRIPTION
The "read more" and "close" buttons now get the padding and margin of the element
that the plugin was applied to, so that they match that element and appear visually
aligned, no matter what element the plugin is applied to.

I had applied this plugin site-wide to all elements with the "readmore" class,
but the target elements had varying margins, causing lots of misalignment.
This meant I couldn't just style the controls to match my styles, as there were so
many different margins to match. 

Manually setting the inline style each time the buttons are created, as I've
done here, is one solution to this issue, although likely not the optimum
solution. 
