### PR TITLE
changed jquery dependency to stated support; so back to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/jedfoster/Readmore.js",
   "dependencies": {
-    "jquery": ">2.1.4"
+    "jquery": "^1.9.1"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
This makes it depend on stated minimum requirements. 
See project readme ;  above v1.9.1 ; though works _from_ v1.9.1 .. so now depends on `^1.9.1` instead of `v2`
-  fixes projects using npm having to shrinkwrap the dependent jquery version when project jquery version is less than v2
  -  fixes projects using [yarn](https://yarnpkg.com) (which ignores shrinkwrap)
