### PR TITLE
Fix #198 - afterToggle does not fire first time when startOpen true

### DIFF
--- a/readmore.js
+++ b/readmore.js
@@ -218,6 +218,10 @@
           current.css({
             height: collapsedHeight
           });
+        } else {
+          current.css({
+            height: current.height()
+          });
         }
 
         if (this.options.blockProcessed && typeof this.options.blockProcessed === 'function') {


### PR DESCRIPTION
Hi Jed,

This fixes #198 by setting the height using the .css method even when startOpen is not set - the first `transitionend` which is triggered when the .css method is called is "compiling" the function. This fixes the behavior, but I'm not sure if we should seek to fix the underlying issue which is that the function remains uncompiled unless transitionend is called at some point. Thoughts?