### PR TITLE
Remove height and maxHeight entirely on destroy()

### DIFF
--- a/src/readmore.js
+++ b/src/readmore.js
@@ -374,8 +374,8 @@ class Readmore {
 
       delete element.readmore;
 
-      element.style.height = 'initial';
-      element.style.maxHeight = 'initial';
+      element.style.height = '';
+      element.style.maxHeight = '';
 
       element.removeAttribute('data-readmore');
       element.removeAttribute('aria-expanded');


### PR DESCRIPTION
Setting them to "initial" breaks the automatic maxHeight (set by the CSS) pickup.
E.g. if the max-height set in the CSS uses relative units (rem, %, vh, vw, etc.), you want to "refresh" the readmore block on resize by destroying it and then initializing it again. That is currently impossible without clearing styles manually like so:

```
        const $el = readMore.elements[0];  
        readMore.destroy(readMore.elements[0]);  
        $el.style.height = '';  
        $el.style.maxHeight = '';  
```