### PR TITLE
fix uniqueId when it is called with no arguments, selector fallback

### DIFF
--- a/readmore.js
+++ b/readmore.js
@@ -69,7 +69,7 @@
   function uniqueId(prefix) {
     var id = ++uniqueIdCounter;
 
-    return String(prefix === null ? 'rmjs-' : prefix) + id;
+    return String((prefix === null || prefix === undefined) ? 'rmjs-' : prefix) + id;
   }
 
   function setBoxHeights(element) {
@@ -312,7 +312,7 @@
 
   $.fn.readmore = function(options) {
     var args = arguments,
-        selector = this.selector;
+        selector = this.selector || options.selector;
 
     options = options || {};
 


### PR DESCRIPTION
prefix is set to undefined when uniqueId is called with no arguments 

this.selector is undefined on latest version of jquery which results in undefined in the generated css, added options.selector so it can be passed in explicitly